### PR TITLE
fix(FRO-63): change nav-bar order

### DIFF
--- a/src/libs/links.js
+++ b/src/libs/links.js
@@ -47,8 +47,7 @@ export const links = [
   { name: 'Home', link: routes.home },
   { name: 'Use cases', link: `${routes.useCases}/1` },
   { name: 'How it work', link: routes.howItWorks },
-  { name: 'Avatars', link: routes.avatars },
-  { name: 'Contact', link: routes.contact }
+  { name: 'Avatars', link: routes.avatars }
 ];
 
 export const navLinks = [


### PR DESCRIPTION
Changed the order of the top navigation bar. 
https://linear.app/hng-team-clutch/issue/FRO-63/change-the-order-of-the-navigation-links-in-the-navbar